### PR TITLE
Support for custom img-loading via slot

### DIFF
--- a/vue2-image-loader.vue
+++ b/vue2-image-loader.vue
@@ -1,11 +1,13 @@
 <template>
 	<div v-if="!url">
 		<div class="img-loading">
-		        <span></span>
-		        <span></span>
-		        <span></span>
-		        <span></span>
-		        <span></span>
+		      <slot name="img-loading">
+				<span></span>
+				<span></span>
+				<span></span>
+				<span></span>
+				<span></span>
+			</slot>
 		</div>
 	</div>
 	<div v-else-if="url" >


### PR DESCRIPTION
Taking profit from Vue slot support, the developer can now override the current img-loading animation with a custom one, e.g. with a FontAwesome icon:
`<ImgLoader imgUrl="someImage" >
                  <template slot="img-loading">
                    <a class="icon is-small">
                      <i class="fas fa-circle-notch fa-spin"></i>
                    </a>
                  </template>
                </ImgLoader>`